### PR TITLE
feat: redesign homepage as Apple-style Bento Grid 3.0

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -86,6 +86,112 @@
                 "description": "Explore a collection of my personal projects and creative works. From design to development, this gallery showcases my passion for creation and innovation.",
                 "go_to_gallery": "Go to Gallery"
             }
+        },
+
+        "bento": {
+            "profile": {
+                "status": "Available in Geneva 🇨🇭",
+                "role": "Software Developer & CS Student",
+                "tagline": "Builder of digital experiences.",
+                "cta": "Get in touch"
+            },
+
+            "clock": {
+                "title": "Geneva, Switzerland"
+            },
+
+            "music": {
+                "now_playing": "Code Soundtrack",
+                "track": "Deep Work Mode",
+                "artist": "Focus Flow",
+                "play": "Play",
+                "pause": "Pause"
+            },
+
+            "stack": {
+                "title": "Stack Lab",
+                "description": "Technologies I work with daily"
+            },
+
+            "github": {
+                "title": "GitHub Activity",
+                "description": "Contribution canvas"
+            },
+
+            "projects": {
+                "label": "Featured Projects",
+                "title": "Selected Works",
+                "view_all": "View all",
+                "nexus": {
+                    "title": "Nexus",
+                    "description": "Minecraft mini-games server — all my creations in one place"
+                },
+                "stranger_hide": {
+                    "title": "Stranger Hide",
+                    "description": "Hide-and-seek server themed around Stranger Things"
+                },
+                "project_family": {
+                    "title": "Project Family",
+                    "description": "Modded survival Minecraft server with a large community"
+                }
+            },
+
+            "timeline": {
+                "label": "My Journey",
+                "title": "Academic & Professional Path",
+                "items": {
+                    "jjr": {
+                        "title": "JJ Rousseau",
+                        "subtitle": "Secondary Certificate",
+                        "date": "2016"
+                    },
+                    "stael": {
+                        "title": "Mme de Staël",
+                        "subtitle": "Scientific Baccalaureate",
+                        "date": "2020"
+                    },
+                    "world_heberg": {
+                        "title": "World-Heberg",
+                        "subtitle": "Moderation Lead & Dev",
+                        "date": "2020"
+                    },
+                    "unige": {
+                        "title": "Univ. of Geneva",
+                        "subtitle": "BSc Computer Science",
+                        "date": "2023"
+                    },
+                    "swerc": {
+                        "title": "SWERC 2024",
+                        "subtitle": "ICPC Regional Contest",
+                        "date": "2024"
+                    },
+                    "redcap": {
+                        "title": "REDCap / HUG",
+                        "subtitle": "Semester Project",
+                        "date": "2025"
+                    }
+                }
+            },
+
+            "contact": {
+                "label": "Open to opportunities",
+                "title": "Let's Connect",
+                "cta_email": "Send an email",
+                "cta_linkedin": "LinkedIn",
+                "cta_github": "GitHub",
+                "cta_form": "Open contact form"
+            },
+
+            "discover": {
+                "label": "Explore",
+                "title": "Discover More",
+                "links": {
+                    "knowledge": "Skills & Education",
+                    "education": "Academic Path",
+                    "career": "Experiences",
+                    "gallery": "Projects Gallery"
+                }
+            }
         }
     },
 

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -86,6 +86,112 @@
                 "description": "Explorez une collection de mes projets personnels et œuvres créatives. Du design au développement, cette galerie présente ma passion pour la création et l'innovation.",
                 "go_to_gallery": "Voir mes réalisations"
             }
+        },
+
+        "bento": {
+            "profile": {
+                "status": "Disponible à Genève 🇨🇭",
+                "role": "Développeur Logiciel & Étudiant en Informatique",
+                "tagline": "Constructeur d'expériences numériques.",
+                "cta": "Me contacter"
+            },
+
+            "clock": {
+                "title": "Genève, Suisse"
+            },
+
+            "music": {
+                "now_playing": "Bande-son du code",
+                "track": "Mode Concentration",
+                "artist": "Focus Flow",
+                "play": "Lecture",
+                "pause": "Pause"
+            },
+
+            "stack": {
+                "title": "Stack Lab",
+                "description": "Technologies que j'utilise au quotidien"
+            },
+
+            "github": {
+                "title": "Activité GitHub",
+                "description": "Graphique de contributions"
+            },
+
+            "projects": {
+                "label": "Projets phares",
+                "title": "Réalisations sélectionnées",
+                "view_all": "Tout voir",
+                "nexus": {
+                    "title": "Nexus",
+                    "description": "Serveur Minecraft de mini-jeux — toutes mes créations réunies"
+                },
+                "stranger_hide": {
+                    "title": "Stranger Hide",
+                    "description": "Serveur cache-cache sur le thème de Stranger Things"
+                },
+                "project_family": {
+                    "title": "Project Family",
+                    "description": "Serveur Minecraft survie moddée avec une grande communauté"
+                }
+            },
+
+            "timeline": {
+                "label": "Mon Parcours",
+                "title": "Chemin Académique & Professionnel",
+                "items": {
+                    "jjr": {
+                        "title": "JJ Rousseau",
+                        "subtitle": "Brevet des Collèges",
+                        "date": "2016"
+                    },
+                    "stael": {
+                        "title": "Mme de Staël",
+                        "subtitle": "Baccalauréat Scientifique",
+                        "date": "2020"
+                    },
+                    "world_heberg": {
+                        "title": "World-Heberg",
+                        "subtitle": "Chef Modération & Dev",
+                        "date": "2020"
+                    },
+                    "unige": {
+                        "title": "Univ. de Genève",
+                        "subtitle": "Bachelor Informatique",
+                        "date": "2023"
+                    },
+                    "swerc": {
+                        "title": "SWERC 2024",
+                        "subtitle": "Concours ICPC Régional",
+                        "date": "2024"
+                    },
+                    "redcap": {
+                        "title": "REDCap / HUG",
+                        "subtitle": "Projet de Semestre",
+                        "date": "2025"
+                    }
+                }
+            },
+
+            "contact": {
+                "label": "Ouvert aux opportunités",
+                "title": "Restons en Contact",
+                "cta_email": "Envoyer un e-mail",
+                "cta_linkedin": "LinkedIn",
+                "cta_github": "GitHub",
+                "cta_form": "Ouvrir le formulaire de contact"
+            },
+
+            "discover": {
+                "label": "Explorer",
+                "title": "Découvrir Plus",
+                "links": {
+                    "knowledge": "Compétences & Formation",
+                    "education": "Parcours Académique",
+                    "career": "Expériences",
+                    "gallery": "Galerie de Projets"
+                }
+            }
         }
     },
 

--- a/src/app/_components/Footer.tsx
+++ b/src/app/_components/Footer.tsx
@@ -12,62 +12,55 @@ import ExternalLink, { ExternalURL } from "./utils/ExternalLink";
 export default function Footer() {
     const t = useTranslations("footer");
 
-    const Brackets = ({ title, children }: { title: string, children: React.ReactNode }) => {
-        return (
-            <div className="flex flex-col gap-4">
-                <h3 className="font-bold text-lg">{title}</h3>
+    const Brackets = ({ title, children }: { title: string; children: React.ReactNode }) => (
+        <div className="flex flex-col gap-4">
+            <h3 className="text-xs font-semibold text-white/30 uppercase tracking-widest">{title}</h3>
+            {children}
+        </div>
+    );
 
-                {children}
-            </div>
-        );
-    }
-
-    const Bracket = ({ links, blank }: { links: ExternalURL[], blank?: boolean }) => {
-        return (
-            <ul className="flex flex-col gap-2">
-                {links.map(link => {
-                    return (
-                        <li key={link.name}>
-                            <ExternalLink url={link} colored={false} blank={blank} />
-                        </li>
-                    )
-                })}
-            </ul>
-        );
-    }
-
+    const Bracket = ({ links, blank }: { links: ExternalURL[]; blank?: boolean }) => (
+        <ul className="flex flex-col gap-2.5">
+            {links.map((link) => (
+                <li key={link.name}>
+                    <ExternalLink url={link} colored={false} blank={blank} />
+                </li>
+            ))}
+        </ul>
+    );
 
     return (
-        <footer className="w-full z-50 bg-primary">
-            <div className="w-full bg-secondary">
-                <div className="flex flex-col xl:flex-row justify-between gap-12 max-w-screen-2xl mx-auto px-10 py-20">
-                    <div className="flex flex-col gap-8">
-                        <figure className="flex w-52 h-28 relative">
-                            <Link href="/"><Image className="object-contain object-center" src="/banner.png" fill={true} alt={t("banner")} /></Link>
-                        </figure>
+        <footer className="w-full border-t border-white/[0.06]" style={{ background: "rgba(9,9,11,0.95)" }}>
+            <div className="flex flex-col xl:flex-row justify-between gap-12 max-w-screen-2xl mx-auto px-10 py-16">
+                <div className="flex flex-col gap-8">
+                    <figure className="flex w-44 h-24 relative">
+                        <Link href="/">
+                            <Image
+                                className="object-contain object-center"
+                                src="/banner.png"
+                                fill
+                                alt={t("banner")}
+                            />
+                        </Link>
+                    </figure>
 
-                        <Brackets title={t("legal")}>
-                            <Bracket links={useLegal()} blank={false} />
-                        </Brackets>
-                    </div>
+                    <Brackets title={t("legal")}>
+                        <Bracket links={useLegal()} blank={false} />
+                    </Brackets>
+                </div>
 
-                    <div className="flex flex-col md:flex-row gap-12 md:gap-24">
-                        <Brackets title={t("navigation")}>
-                            <Bracket links={useMenu()} blank={false} />
-                        </Brackets>
+                <div className="flex flex-col md:flex-row gap-12 md:gap-24">
+                    <Brackets title={t("navigation")}>
+                        <Bracket links={useMenu()} blank={false} />
+                    </Brackets>
 
-                        <Brackets title={t("resources")}>
-                            <Bracket links={useResources()} blank={true} />
-                        </Brackets>
-
-                        {/* <Brackets title={t("location")}>
-                            <Location/>
-                        </Brackets> */}
-                    </div>
+                    <Brackets title={t("resources")}>
+                        <Bracket links={useResources()} blank />
+                    </Brackets>
                 </div>
             </div>
 
-            <div className="flex flex-col items-center justify-center p-4 text-center">
+            <div className="border-t border-white/[0.05] flex flex-col items-center justify-center p-5 text-center">
                 <Copyright />
             </div>
         </footer>

--- a/src/app/_components/Header.tsx
+++ b/src/app/_components/Header.tsx
@@ -1,8 +1,9 @@
-import Navbar from './navigation/navbar/Navbar';
+import Navbar from "./navigation/navbar/Navbar";
 
 export default function Header() {
     return (
-        <header className="w-full sticky top-0 z-50 bg-primary">
+        <header className="w-full sticky top-0 z-50 border-b border-white/[0.06]"
+            style={{ background: "rgba(9,9,11,0.80)", backdropFilter: "blur(20px)" }}>
             <Navbar />
         </header>
     );

--- a/src/app/_components/bento/ClockWidget.tsx
+++ b/src/app/_components/bento/ClockWidget.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { useTranslations } from "next-intl";
+import { useEffect, useState } from "react";
+
+export default function ClockWidget() {
+    const t = useTranslations("home.bento.clock");
+    const [time, setTime] = useState<Date | null>(null);
+
+    useEffect(() => {
+        const tick = () => {
+            setTime(new Date(new Date().toLocaleString("en-US", { timeZone: "Europe/Zurich" })));
+        };
+        tick();
+        const id = setInterval(tick, 1000);
+        return () => clearInterval(id);
+    }, []);
+
+    const hours = time ? time.getHours() : 12;
+    const isDaytime = hours >= 6 && hours < 20;
+    const hoursStr = time ? hours.toString().padStart(2, "0") : "--";
+    const minutesStr = time ? time.getMinutes().toString().padStart(2, "0") : "--";
+    const secondsStr = time ? time.getSeconds().toString().padStart(2, "0") : "--";
+
+    const dateStr = time
+        ? time.toLocaleDateString("en-CH", { weekday: "short", month: "short", day: "numeric" })
+        : "";
+
+    return (
+        <motion.div
+            className="relative h-full rounded-3xl border border-white/[0.08] bg-neutral-900/60 backdrop-blur-xl p-6 flex flex-col justify-between overflow-hidden"
+            whileHover={{ scale: 1.015, y: -3 }}
+            transition={{ type: "spring", stiffness: 300, damping: 25 }}
+        >
+            {/* Sky tint */}
+            <div
+                className="absolute inset-0 pointer-events-none"
+                style={{
+                    background: isDaytime
+                        ? "radial-gradient(circle at 80% 20%, rgba(251,191,36,0.06) 0%, transparent 60%)"
+                        : "radial-gradient(circle at 80% 20%, rgba(99,102,241,0.08) 0%, transparent 60%)",
+                }}
+            />
+
+            <div className="relative z-10">
+                <p className="text-[11px] font-semibold text-white/35 uppercase tracking-widest mb-4">
+                    {t("title")}
+                </p>
+
+                {/* Digital clock */}
+                <div className="tabular-nums leading-none">
+                    <span className="text-[2.6rem] font-black text-white tracking-tight">
+                        {hoursStr}:{minutesStr}
+                    </span>
+                    <span className="text-lg font-light text-white/25 ml-1">:{secondsStr}</span>
+                </div>
+
+                <p className="mt-2 text-xs text-white/30 font-medium">{dateStr}</p>
+            </div>
+
+            {/* Sky icon */}
+            <div className="relative z-10">
+                {isDaytime ? <SunIcon /> : <MoonIcon />}
+            </div>
+        </motion.div>
+    );
+}
+
+function SunIcon() {
+    return (
+        <motion.div
+            className="w-10 h-10 rounded-full"
+            style={{
+                background: "radial-gradient(circle, #fbbf24 0%, #f97316 100%)",
+                boxShadow: "0 0 30px rgba(251,191,36,0.35)",
+            }}
+            animate={{ scale: [1, 1.06, 1] }}
+            transition={{ duration: 3, repeat: Infinity, ease: "easeInOut" }}
+        />
+    );
+}
+
+function MoonIcon() {
+    return (
+        <motion.div
+            className="w-10 h-10 flex items-center justify-center"
+            animate={{ rotate: [0, 4, 0] }}
+            transition={{ duration: 5, repeat: Infinity, ease: "easeInOut" }}
+        >
+            <svg viewBox="0 0 40 40" className="w-9 h-9">
+                <defs>
+                    <radialGradient id="moonGrad" cx="40%" cy="40%">
+                        <stop offset="0%" stopColor="#e0e7ff" />
+                        <stop offset="100%" stopColor="#a5b4fc" />
+                    </radialGradient>
+                </defs>
+                <path
+                    d="M22 8 C14 8, 8 14, 8 22 C8 30, 14 36, 22 36 C26 36, 30 34, 32 31 C28 31, 24 27, 24 22 C24 17, 27 13, 31 12 C28 9.5, 25 8, 22 8Z"
+                    fill="url(#moonGrad)"
+                    opacity="0.85"
+                />
+                <circle cx="33" cy="11" r="1.2" fill="rgba(255,255,255,0.5)" />
+                <circle cx="36" cy="18" r="0.8" fill="rgba(255,255,255,0.35)" />
+                <circle cx="31" cy="26" r="0.9" fill="rgba(255,255,255,0.4)" />
+            </svg>
+        </motion.div>
+    );
+}

--- a/src/app/_components/bento/ContactWidget.tsx
+++ b/src/app/_components/bento/ContactWidget.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { faEnvelope } from "@fortawesome/free-solid-svg-icons";
+import { faGithub, faLinkedin } from "@fortawesome/free-brands-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { motion } from "framer-motion";
+import { useTranslations } from "next-intl";
+import Link from "next/link";
+import { ReactNode } from "react";
+
+interface ContactLinkProps {
+    href: string;
+    icon: ReactNode;
+    label: string;
+    accentClass: string;
+    external?: boolean;
+}
+
+function ContactLink({ href, icon, label, accentClass, external }: ContactLinkProps) {
+    return (
+        <motion.a
+            href={href}
+            target={external ? "_blank" : undefined}
+            rel={external ? "noopener noreferrer" : undefined}
+            className={`flex items-center gap-2.5 px-3.5 py-2.5 rounded-2xl border text-xs font-semibold transition-colors ${accentClass}`}
+            whileHover={{ x: 3 }}
+            transition={{ type: "spring", stiffness: 400, damping: 25 }}
+        >
+            <span className="w-3.5 h-3.5 flex-shrink-0">{icon}</span>
+            {label}
+        </motion.a>
+    );
+}
+
+export default function ContactWidget() {
+    const t = useTranslations("home.bento.contact");
+
+    return (
+        <motion.div
+            className="relative h-full rounded-3xl border border-white/[0.08] bg-neutral-900/60 backdrop-blur-xl p-6 overflow-hidden flex flex-col justify-between"
+            whileHover={{ scale: 1.01, y: -2 }}
+            transition={{ type: "spring", stiffness: 300, damping: 25 }}
+        >
+            <div
+                className="absolute inset-0 pointer-events-none"
+                style={{
+                    background:
+                        "radial-gradient(circle at 0% 0%, rgba(99,102,241,0.1) 0%, transparent 60%)",
+                }}
+            />
+
+            <div className="relative z-10">
+                <p className="text-[11px] font-semibold text-white/35 uppercase tracking-widest mb-1">
+                    {t("label")}
+                </p>
+                <h2 className="text-xl font-black text-white mb-5">{t("title")}</h2>
+
+                <div className="flex flex-col gap-2">
+                    <ContactLink
+                        href="mailto:contact@agonkolgeci.com"
+                        icon={<FontAwesomeIcon icon={faEnvelope} />}
+                        label={t("cta_email")}
+                        accentClass="bg-blue-500/10 border-blue-500/20 text-blue-400 hover:bg-blue-500/15"
+                        external
+                    />
+                    <ContactLink
+                        href="https://linkedin.com/in/agon-kolgeci-193aa2266/"
+                        icon={<FontAwesomeIcon icon={faLinkedin} />}
+                        label={t("cta_linkedin")}
+                        accentClass="bg-sky-500/10 border-sky-500/20 text-sky-400 hover:bg-sky-500/15"
+                        external
+                    />
+                    <ContactLink
+                        href="https://github.com/agonkolgeci"
+                        icon={<FontAwesomeIcon icon={faGithub} />}
+                        label={t("cta_github")}
+                        accentClass="bg-purple-500/10 border-purple-500/20 text-purple-400 hover:bg-purple-500/15"
+                        external
+                    />
+                </div>
+            </div>
+
+            <Link
+                href="/contact"
+                className="relative z-10 w-full py-2.5 rounded-2xl bg-white/[0.06] border border-white/10 text-xs font-semibold text-white/50 hover:bg-white/10 hover:text-white transition-all text-center block"
+            >
+                {t("cta_form")} →
+            </Link>
+        </motion.div>
+    );
+}

--- a/src/app/_components/bento/DiscoverWidget.tsx
+++ b/src/app/_components/bento/DiscoverWidget.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { useTranslations } from "next-intl";
+import Link from "next/link";
+
+const NAV_LINKS = [
+    { key: "knowledge", href: "/skills", emoji: "⚡", gradient: "from-blue-950/70 to-blue-900/20" },
+    { key: "education", href: "/education", emoji: "🎓", gradient: "from-emerald-950/70 to-emerald-900/20" },
+    { key: "career", href: "/experiences", emoji: "💼", gradient: "from-amber-950/70 to-amber-900/20" },
+    { key: "gallery", href: "/gallery", emoji: "🚀", gradient: "from-purple-950/70 to-purple-900/20" },
+];
+
+export default function DiscoverWidget() {
+    const t = useTranslations("home.bento.discover");
+
+    return (
+        <motion.div
+            className="relative h-full rounded-3xl border border-white/[0.08] bg-neutral-900/60 backdrop-blur-xl p-6 overflow-hidden"
+            whileHover={{ scale: 1.01, y: -2 }}
+            transition={{ type: "spring", stiffness: 300, damping: 25 }}
+        >
+            <div className="relative z-10 mb-4">
+                <p className="text-[11px] font-semibold text-white/35 uppercase tracking-widest mb-0.5">
+                    {t("label")}
+                </p>
+                <p className="text-sm font-bold text-white">{t("title")}</p>
+            </div>
+
+            <div className="relative z-10 grid grid-cols-2 gap-2.5">
+                {NAV_LINKS.map(({ key, href, emoji, gradient }, i) => (
+                    <Link key={key} href={href}>
+                        <motion.div
+                            className={`rounded-2xl bg-gradient-to-br ${gradient} border border-white/[0.07] p-4 flex flex-col gap-2.5`}
+                            initial={{ opacity: 0, scale: 0.95 }}
+                            animate={{ opacity: 1, scale: 1 }}
+                            transition={{ delay: i * 0.06 }}
+                            whileHover={{ scale: 1.04, y: -2 }}
+                        >
+                            <span className="text-2xl">{emoji}</span>
+                            <span className="text-xs font-semibold text-white/65 leading-tight">
+                                {t(`links.${key}`)}
+                            </span>
+                        </motion.div>
+                    </Link>
+                ))}
+            </div>
+        </motion.div>
+    );
+}

--- a/src/app/_components/bento/GitHubWidget.tsx
+++ b/src/app/_components/bento/GitHubWidget.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { useTranslations } from "next-intl";
+
+function hash(w: number, d: number): number {
+    const n = Math.sin(w * 127.1 + d * 311.7 + 43.0) * 43758.5453;
+    return n - Math.floor(n);
+}
+
+const GRID = Array.from({ length: 52 }, (_, w) =>
+    Array.from({ length: 7 }, (_, d) => {
+        const v = hash(w, d);
+        if (v < 0.48) return 0;
+        if (v < 0.68) return 1;
+        if (v < 0.82) return 2;
+        if (v < 0.92) return 3;
+        return 4;
+    })
+);
+
+const CELL_CLASSES = [
+    "bg-white/[0.04]",
+    "bg-emerald-900/60",
+    "bg-emerald-700/65",
+    "bg-emerald-500/75",
+    "bg-emerald-400/90",
+];
+
+const CELL_SHADOWS = [
+    "",
+    "",
+    "",
+    "0 0 4px rgba(52,211,153,0.3)",
+    "0 0 6px rgba(52,211,153,0.5)",
+];
+
+export default function GitHubWidget() {
+    const t = useTranslations("home.bento.github");
+
+    return (
+        <motion.div
+            className="relative h-full rounded-3xl border border-white/[0.08] bg-neutral-900/60 backdrop-blur-xl p-6 overflow-hidden"
+            whileHover={{ scale: 1.01, y: -2 }}
+            transition={{ type: "spring", stiffness: 300, damping: 25 }}
+        >
+            <div
+                className="absolute inset-0 pointer-events-none"
+                style={{
+                    background:
+                        "radial-gradient(circle at 90% 10%, rgba(34,197,94,0.05) 0%, transparent 60%)",
+                }}
+            />
+
+            <div className="relative z-10 flex items-start justify-between mb-4">
+                <div>
+                    <p className="text-[11px] font-semibold text-white/35 uppercase tracking-widest mb-0.5">
+                        {t("title")}
+                    </p>
+                    <p className="text-sm font-bold text-white">{t("description")}</p>
+                </div>
+                <a
+                    href="https://github.com/agonkolgeci"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-[11px] text-white/25 hover:text-white/50 transition-colors font-mono"
+                >
+                    @agonkolgeci
+                </a>
+            </div>
+
+            {/* Contribution grid */}
+            <div className="relative z-10 overflow-x-auto scrollbar-hide">
+                <div className="flex gap-[3px] min-w-max">
+                    {GRID.map((week, w) => (
+                        <div key={w} className="flex flex-col gap-[3px]">
+                            {week.map((level, d) => (
+                                <motion.div
+                                    key={d}
+                                    className={`w-[10px] h-[10px] rounded-sm ${CELL_CLASSES[level]}`}
+                                    style={
+                                        CELL_SHADOWS[level]
+                                            ? { boxShadow: CELL_SHADOWS[level] }
+                                            : undefined
+                                    }
+                                    whileHover={{ scale: 1.6 }}
+                                    transition={{ duration: 0.1 }}
+                                />
+                            ))}
+                        </div>
+                    ))}
+                </div>
+            </div>
+        </motion.div>
+    );
+}

--- a/src/app/_components/bento/MusicWidget.tsx
+++ b/src/app/_components/bento/MusicWidget.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { useTranslations } from "next-intl";
+import { useState } from "react";
+
+const WAVE_COUNT = 18;
+const WAVE_HEIGHTS = [30, 55, 75, 60, 40, 85, 50, 70, 35, 65, 80, 45, 90, 55, 40, 70, 60, 35];
+
+export default function MusicWidget() {
+    const t = useTranslations("home.bento.music");
+    const [isPlaying, setIsPlaying] = useState(true);
+
+    return (
+        <motion.div
+            className="relative h-full rounded-3xl border border-white/[0.08] bg-neutral-900/60 backdrop-blur-xl p-6 overflow-hidden flex flex-col justify-between"
+            whileHover={{ scale: 1.015, y: -3 }}
+            transition={{ type: "spring", stiffness: 300, damping: 25 }}
+        >
+            <div
+                className="absolute inset-0 pointer-events-none"
+                style={{
+                    background: "radial-gradient(circle at 80% 80%, rgba(139,92,246,0.08) 0%, transparent 60%)",
+                }}
+            />
+
+            <div className="relative z-10">
+                <p className="text-[11px] font-semibold text-white/35 uppercase tracking-widest mb-4">
+                    {t("now_playing")}
+                </p>
+
+                {/* Vinyl + info */}
+                <div className="flex items-center gap-4">
+                    <motion.div
+                        className="relative w-14 h-14 rounded-full flex-shrink-0"
+                        animate={{ rotate: isPlaying ? 360 : 0 }}
+                        transition={{
+                            duration: 8,
+                            repeat: Infinity,
+                            ease: "linear",
+                            repeatType: "loop",
+                        }}
+                        style={{ animationPlayState: isPlaying ? "running" : "paused" }}
+                    >
+                        <div className="w-full h-full rounded-full bg-gradient-to-br from-neutral-700 to-neutral-900 border border-white/10 flex items-center justify-center">
+                            <div className="absolute inset-[6px] rounded-full border border-white/[0.06]" />
+                            <div className="absolute inset-[10px] rounded-full border border-white/[0.04]" />
+                            <div className="absolute inset-[14px] rounded-full border border-white/[0.04]" />
+                            <div className="w-4 h-4 rounded-full bg-purple-500/50 border border-purple-400/30 z-10" />
+                        </div>
+                    </motion.div>
+
+                    <div className="flex-1 min-w-0">
+                        <p className="text-sm font-bold text-white truncate">{t("track")}</p>
+                        <p className="text-xs text-white/35 truncate">{t("artist")}</p>
+                    </div>
+                </div>
+            </div>
+
+            {/* Waveform */}
+            <div className="relative z-10 flex items-end gap-[3px] h-8">
+                {WAVE_HEIGHTS.slice(0, WAVE_COUNT).map((baseH, i) => (
+                    <motion.div
+                        key={i}
+                        className="flex-1 rounded-full bg-purple-400/55"
+                        animate={
+                            isPlaying
+                                ? {
+                                      scaleY: [baseH / 100, Math.min((baseH + 30) / 100, 1), baseH / 100],
+                                  }
+                                : { scaleY: 0.15 }
+                        }
+                        style={{ originY: 1 }}
+                        transition={{
+                            duration: 1.1 + (i % 4) * 0.15,
+                            repeat: Infinity,
+                            ease: "easeInOut",
+                            delay: i * 0.06,
+                        }}
+                    />
+                ))}
+            </div>
+
+            {/* Controls */}
+            <div className="relative z-10 flex items-center gap-3">
+                <button
+                    onClick={() => setIsPlaying(!isPlaying)}
+                    className="w-8 h-8 rounded-full bg-white/[0.08] border border-white/10 flex items-center justify-center text-white/50 hover:bg-white/15 hover:text-white transition-all"
+                    aria-label={isPlaying ? t("pause") : t("play")}
+                >
+                    {isPlaying ? (
+                        <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 24 24">
+                            <rect x="6" y="4" width="4" height="16" rx="1" />
+                            <rect x="14" y="4" width="4" height="16" rx="1" />
+                        </svg>
+                    ) : (
+                        <svg className="w-3 h-3 ml-0.5" fill="currentColor" viewBox="0 0 24 24">
+                            <polygon points="5,3 19,12 5,21" />
+                        </svg>
+                    )}
+                </button>
+                <div className="flex-1 h-px bg-white/10 rounded-full overflow-hidden">
+                    <motion.div
+                        className="h-full bg-purple-400/60 rounded-full"
+                        animate={isPlaying ? { width: ["30%", "75%"] } : {}}
+                        transition={{ duration: 120, ease: "linear" }}
+                        style={{ width: "30%" }}
+                    />
+                </div>
+            </div>
+        </motion.div>
+    );
+}

--- a/src/app/_components/bento/ProfileCard.tsx
+++ b/src/app/_components/bento/ProfileCard.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { motion, useMotionValue, useSpring, useTransform } from "framer-motion";
+import { useTranslations } from "next-intl";
+import Image from "next/image";
+import Link from "next/link";
+import { useRef } from "react";
+import SocialsLinks from "../navigation/socials/SocialsLinks";
+
+export default function ProfileCard() {
+    const t = useTranslations("home.bento.profile");
+    const ref = useRef<HTMLDivElement>(null);
+
+    const x = useMotionValue(0);
+    const y = useMotionValue(0);
+
+    const xSpring = useSpring(x, { stiffness: 150, damping: 20 });
+    const ySpring = useSpring(y, { stiffness: 150, damping: 20 });
+
+    const rotateX = useTransform(ySpring, [-0.5, 0.5], ["7deg", "-7deg"]);
+    const rotateY = useTransform(xSpring, [-0.5, 0.5], ["-7deg", "7deg"]);
+
+    function handleMouseMove(e: React.MouseEvent<HTMLDivElement>) {
+        if (!ref.current) return;
+        const rect = ref.current.getBoundingClientRect();
+        x.set((e.clientX - rect.left) / rect.width - 0.5);
+        y.set((e.clientY - rect.top) / rect.height - 0.5);
+    }
+
+    function handleMouseLeave() {
+        x.set(0);
+        y.set(0);
+    }
+
+    return (
+        <div
+            ref={ref}
+            onMouseMove={handleMouseMove}
+            onMouseLeave={handleMouseLeave}
+            className="h-full"
+            style={{ perspective: "1200px" }}
+        >
+            <motion.div
+                className="relative h-full rounded-3xl border border-white/[0.08] bg-neutral-900/60 backdrop-blur-xl overflow-hidden p-7 flex flex-col justify-between"
+                style={{ rotateX, rotateY, transformStyle: "preserve-3d" }}
+            >
+                {/* Ambient glow */}
+                <div
+                    className="absolute -top-20 -left-20 w-64 h-64 rounded-full pointer-events-none"
+                    style={{ background: "radial-gradient(circle, rgba(99,102,241,0.12) 0%, transparent 70%)" }}
+                />
+
+                <div style={{ transform: "translateZ(25px)" }}>
+                    {/* Live status */}
+                    <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-emerald-500/10 border border-emerald-500/20 mb-6">
+                        <span className="relative flex size-1.5">
+                            <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75" />
+                            <span className="relative inline-flex rounded-full size-1.5 bg-emerald-400" />
+                        </span>
+                        <span className="text-[11px] font-semibold text-emerald-400">{t("status")}</span>
+                    </div>
+
+                    {/* Portrait */}
+                    <div className="relative w-[72px] h-[72px] rounded-2xl overflow-hidden mb-5 ring-2 ring-white/10">
+                        <Image
+                            src="/home/portrait.webp"
+                            fill
+                            alt="Agon KOLGECI"
+                            className="object-cover object-center"
+                        />
+                    </div>
+
+                    {/* Identity */}
+                    <h1 className="text-2xl font-black text-white leading-tight mb-1.5">Agon KOLGECI</h1>
+                    <p className="text-xs font-semibold text-white/40 mb-1 tracking-wide uppercase">{t("role")}</p>
+                    <p className="text-sm text-white/25 leading-relaxed">{t("tagline")}</p>
+                </div>
+
+                <div style={{ transform: "translateZ(20px)" }}>
+                    <SocialsLinks className="flex flex-row gap-5 text-lg text-white/40 mb-5" />
+
+                    <Link
+                        href="/contact"
+                        className="inline-flex items-center gap-2 px-4 py-2.5 rounded-2xl bg-white/[0.06] border border-white/10 text-xs font-semibold text-white/60 hover:bg-white/10 hover:text-white transition-all duration-200"
+                    >
+                        {t("cta")}
+                        <span className="opacity-50">→</span>
+                    </Link>
+                </div>
+            </motion.div>
+        </div>
+    );
+}

--- a/src/app/_components/bento/ProjectsWidget.tsx
+++ b/src/app/_components/bento/ProjectsWidget.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { useTranslations } from "next-intl";
+import Link from "next/link";
+
+const PROJECTS = [
+    {
+        key: "nexus",
+        accent: "#6366f1",
+        glow: "rgba(99,102,241,0.1)",
+        border: "rgba(99,102,241,0.2)",
+        tags: ["Java", "Minecraft", "Spigot"],
+    },
+    {
+        key: "stranger_hide",
+        accent: "#ef4444",
+        glow: "rgba(239,68,68,0.1)",
+        border: "rgba(239,68,68,0.2)",
+        tags: ["Java", "Bukkit", "Custom Maps"],
+    },
+    {
+        key: "project_family",
+        accent: "#22c55e",
+        glow: "rgba(34,197,94,0.1)",
+        border: "rgba(34,197,94,0.2)",
+        tags: ["Minecraft", "Modded", "Community"],
+    },
+];
+
+export default function ProjectsWidget() {
+    const t = useTranslations("home.bento.projects");
+
+    return (
+        <motion.div
+            className="relative h-full rounded-3xl border border-white/[0.08] bg-neutral-900/60 backdrop-blur-xl p-6 overflow-hidden flex flex-col"
+            whileHover={{ scale: 1.01, y: -2 }}
+            transition={{ type: "spring", stiffness: 300, damping: 25 }}
+        >
+            <div className="flex items-center justify-between mb-4">
+                <div>
+                    <p className="text-[11px] font-semibold text-white/35 uppercase tracking-widest mb-0.5">
+                        {t("label")}
+                    </p>
+                    <p className="text-sm font-bold text-white">{t("title")}</p>
+                </div>
+                <Link
+                    href="/gallery"
+                    className="text-[11px] text-white/30 hover:text-white/60 transition-colors font-medium"
+                >
+                    {t("view_all")} →
+                </Link>
+            </div>
+
+            <div className="flex flex-col gap-2.5 flex-1">
+                {PROJECTS.map((project, i) => (
+                    <Link key={project.key} href="/gallery">
+                        <motion.div
+                            className="relative rounded-2xl border p-3.5 overflow-hidden cursor-pointer flex items-center gap-3"
+                            style={{
+                                backgroundColor: project.glow,
+                                borderColor: project.border,
+                            }}
+                            initial={{ opacity: 0, x: -10 }}
+                            animate={{ opacity: 1, x: 0 }}
+                            transition={{ delay: i * 0.07 }}
+                            whileHover={{ x: 4 }}
+                        >
+                            {/* Accent stripe */}
+                            <div
+                                className="absolute left-0 inset-y-0 w-0.5 rounded-r-full"
+                                style={{ backgroundColor: project.accent }}
+                            />
+
+                            <div className="flex-1 min-w-0 pl-2">
+                                <p className="text-sm font-bold text-white">{t(`${project.key}.title`)}</p>
+                                <p className="text-xs text-white/40 truncate mt-0.5">
+                                    {t(`${project.key}.description`)}
+                                </p>
+                            </div>
+
+                            <div className="flex gap-1 flex-shrink-0">
+                                {project.tags.slice(0, 2).map((tag) => (
+                                    <span
+                                        key={tag}
+                                        className="text-[9px] px-1.5 py-0.5 rounded-full bg-white/[0.05] border border-white/10 text-white/35 font-medium"
+                                    >
+                                        {tag}
+                                    </span>
+                                ))}
+                            </div>
+                        </motion.div>
+                    </Link>
+                ))}
+            </div>
+        </motion.div>
+    );
+}

--- a/src/app/_components/bento/StackWidget.tsx
+++ b/src/app/_components/bento/StackWidget.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { useTranslations } from "next-intl";
+
+const TECH_STACK = [
+    { name: "React", color: "#61dafb" },
+    { name: "Next.js", color: "#ffffff" },
+    { name: "TypeScript", color: "#3178c6" },
+    { name: "Java", color: "#f89820" },
+    { name: "Redis", color: "#dc382d" },
+    { name: "C++", color: "#00599c" },
+    { name: "Docker", color: "#2496ed" },
+    { name: "Git", color: "#f05032" },
+    { name: "PHP", color: "#8892bf" },
+    { name: "Linux", color: "#fcc624" },
+    { name: "Tailwind", color: "#38bdf8" },
+    { name: "PostgreSQL", color: "#336791" },
+];
+
+export default function StackWidget() {
+    const t = useTranslations("home.bento.stack");
+
+    return (
+        <motion.div
+            className="relative h-full rounded-3xl border border-white/[0.08] bg-neutral-900/60 backdrop-blur-xl p-6 overflow-hidden"
+            whileHover={{ scale: 1.01, y: -2 }}
+            transition={{ type: "spring", stiffness: 300, damping: 25 }}
+        >
+            <div
+                className="absolute inset-0 pointer-events-none"
+                style={{
+                    background:
+                        "radial-gradient(circle at 10% 90%, rgba(59,130,246,0.07) 0%, transparent 60%)",
+                }}
+            />
+
+            <div className="relative z-10 mb-4">
+                <p className="text-[11px] font-semibold text-white/35 uppercase tracking-widest mb-0.5">
+                    {t("title")}
+                </p>
+                <p className="text-sm font-bold text-white">{t("description")}</p>
+            </div>
+
+            <div className="relative z-10 grid grid-cols-3 gap-2">
+                {TECH_STACK.map((tech, i) => (
+                    <motion.div
+                        key={tech.name}
+                        className="flex items-center gap-2 px-2.5 py-2 rounded-xl bg-white/[0.04] border border-white/[0.07] cursor-default"
+                        initial={{ opacity: 0, y: 8 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        transition={{ delay: i * 0.04, duration: 0.3 }}
+                        whileHover={{
+                            backgroundColor: "rgba(255,255,255,0.07)",
+                            borderColor: "rgba(255,255,255,0.14)",
+                        }}
+                    >
+                        <span
+                            className="w-1.5 h-1.5 rounded-full flex-shrink-0"
+                            style={{ backgroundColor: tech.color, boxShadow: `0 0 6px ${tech.color}60` }}
+                        />
+                        <span className="text-[11px] font-medium text-white/60 truncate">{tech.name}</span>
+                    </motion.div>
+                ))}
+            </div>
+        </motion.div>
+    );
+}

--- a/src/app/_components/bento/TimelineWidget.tsx
+++ b/src/app/_components/bento/TimelineWidget.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { useTranslations } from "next-intl";
+
+const TIMELINE_KEYS = [
+    { key: "jjr", icon: "🎓", accent: "#6b7280" },
+    { key: "stael", icon: "🎓", accent: "#3b82f6" },
+    { key: "world_heberg", icon: "💼", accent: "#22c55e" },
+    { key: "unige", icon: "🎓", accent: "#D6005A" },
+    { key: "swerc", icon: "🏆", accent: "#f59e0b" },
+    { key: "redcap", icon: "⚕️", accent: "#a855f7" },
+];
+
+export default function TimelineWidget() {
+    const t = useTranslations("home.bento.timeline");
+
+    return (
+        <motion.div
+            className="relative rounded-3xl border border-white/[0.08] bg-neutral-900/60 backdrop-blur-xl p-6 overflow-hidden"
+            whileHover={{ scale: 1.005 }}
+            transition={{ type: "spring", stiffness: 300, damping: 25 }}
+        >
+            <div
+                className="absolute inset-0 pointer-events-none"
+                style={{
+                    background:
+                        "radial-gradient(ellipse at 50% 0%, rgba(99,102,241,0.05) 0%, transparent 70%)",
+                }}
+            />
+
+            <div className="relative z-10 mb-6">
+                <p className="text-[11px] font-semibold text-white/35 uppercase tracking-widest mb-0.5">
+                    {t("label")}
+                </p>
+                <p className="text-sm font-bold text-white">{t("title")}</p>
+            </div>
+
+            {/* Horizontal timeline */}
+            <div className="relative z-10">
+                {/* Connector line */}
+                <div className="absolute top-5 left-5 right-5 h-px bg-white/[0.07]" />
+
+                <div className="flex gap-3 overflow-x-auto scrollbar-hide pb-2">
+                    {TIMELINE_KEYS.map(({ key, icon, accent }, i) => (
+                        <motion.div
+                            key={key}
+                            className="flex flex-col items-center gap-2.5 flex-shrink-0 w-[110px]"
+                            initial={{ opacity: 0, y: 14 }}
+                            animate={{ opacity: 1, y: 0 }}
+                            transition={{ delay: i * 0.07 }}
+                        >
+                            {/* Node */}
+                            <div
+                                className="w-10 h-10 rounded-full flex items-center justify-center text-base z-10 border relative bg-neutral-900"
+                                style={{
+                                    borderColor: `${accent}40`,
+                                    boxShadow: `0 0 14px ${accent}25`,
+                                }}
+                            >
+                                {icon}
+                            </div>
+
+                            {/* Year */}
+                            <p className="text-[10px] font-bold text-white/50 font-mono">
+                                {t(`items.${key}.date`)}
+                            </p>
+
+                            {/* Title */}
+                            <p className="text-[11px] font-semibold text-white/70 text-center leading-tight">
+                                {t(`items.${key}.title`)}
+                            </p>
+
+                            {/* Subtitle */}
+                            <p className="text-[10px] text-white/30 text-center leading-tight">
+                                {t(`items.${key}.subtitle`)}
+                            </p>
+                        </motion.div>
+                    ))}
+                </div>
+            </div>
+        </motion.div>
+    );
+}

--- a/src/app/_components/navigation/navbar/menu/NavMenu.tsx
+++ b/src/app/_components/navigation/navbar/menu/NavMenu.tsx
@@ -14,35 +14,50 @@ export default function NavMenu() {
 
     const [opened, setOpened] = useState(false);
 
-    const toggleMenu = useCallback(() => setOpened(curr => !curr), []);
+    const toggleMenu = useCallback(() => setOpened((curr) => !curr), []);
     const closeMenu = useCallback(() => setOpened(false), []);
 
-    const NavLinks = () => {
-        return (
-            useMenu().map(link => {
-                return (
-                    <li key={link.name} onClick={closeMenu}>
-                        <Link href={link.href} className={pathname === link.href ? "border-white border-b-2 pb-0.5" : "hover:underline"}>{link.name}</Link>
-                    </li>
-                )
-            })
-        )
-    }
+    const NavLinks = () =>
+        useMenu().map((link) => (
+            <li key={link.name} onClick={closeMenu}>
+                <Link
+                    href={link.href}
+                    className={
+                        pathname === link.href
+                            ? "text-white font-semibold border-b border-white/40 pb-0.5"
+                            : "text-white/50 font-medium hover:text-white/90 transition-colors duration-200"
+                    }
+                >
+                    {link.name}
+                </Link>
+            </li>
+        ));
 
     return (
         <div className="flex flex-row">
-            {/* DESKTOP VIEW */}
-            <ul className="hidden lg:flex flex-row font-semibold gap-8">
-                <NavLinks/>
+            {/* Desktop */}
+            <ul className="hidden lg:flex flex-row gap-8 text-sm">
+                <NavLinks />
             </ul>
 
-            {/* TABLET VIEW */}
+            {/* Mobile */}
             <div className="flex lg:hidden flex-row">
-                <FontAwesomeIcon className="hover:cursor-pointer size-6" icon={opened ? faClose : faBars} onClick={toggleMenu} />
+                <button
+                    onClick={toggleMenu}
+                    className="text-white/50 hover:text-white transition-colors"
+                    aria-label="Toggle menu"
+                >
+                    <FontAwesomeIcon className="size-5" icon={opened ? faClose : faBars} />
+                </button>
 
-                { opened && (<ul className="flex lg:hidden flex-col absolute top-full right-0 w-full h-max p-10 gap-8 text-xl font-semibold border-t border-t-white bg-primary overflow-y-auto">
-                    <NavLinks/>
-                </ul>) }
+                {opened && (
+                    <ul
+                        className="flex lg:hidden flex-col absolute top-full right-0 w-full p-8 gap-6 text-lg font-medium border-t border-white/[0.06]"
+                        style={{ background: "rgba(9,9,11,0.96)", backdropFilter: "blur(20px)" }}
+                    >
+                        <NavLinks />
+                    </ul>
+                )}
             </div>
         </div>
     );

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,44 +2,60 @@
 
 @theme {
     /* Fonts */
-    --font-primary: 'Montserrat', sans-serif;
-    --font-secondary: 'Poppins', sans-serif;
-    
-    /* Colors */
-    --color-primary: #152238;
-    --color-secondary: #192841;
-    --color-tertiary: #1c2e4a;
-    --color-quaternary: #203354;
-    --color-quinary: #23395d;
+    --font-primary: var(--font-space-grotesk, 'Space Grotesk'), sans-serif;
+    --font-secondary: var(--font-inter, 'Inter'), sans-serif;
 
-    /* Background Images */
-    --background-image-gradient-primary: linear-gradient(90deg, rgba(255,255,255,1) 0%, rgba(121,157,255,1) 50%, rgba(66,90,175,1) 100%);
-    
+    /* Colors — Obsidian Dark */
+    --color-primary: #09090b;
+    --color-secondary: #0f0f11;
+    --color-tertiary: #141416;
+    --color-quaternary: #18181b;
+    --color-quinary: #1c1c1f;
+
+    /* Gradients */
+    --background-image-gradient-primary: linear-gradient(135deg, #6366f1 0%, #8b5cf6 50%, #06b6d4 100%);
+
     /* Animations */
     --animation-infinite-scroll: infinite-scroll 20s linear infinite;
     --animation-spiral-in: spiral-in 2s backwards;
+    --animation-spin-slow: spin-slow 20s linear infinite;
+    --animation-float: float 6s ease-in-out infinite;
+    --animation-glow-pulse: glow-pulse 3s ease-in-out infinite;
+    --animation-wave: wave 1.5s ease-in-out infinite;
 }
 
 :root {
-    --navbar-height: 50px;
+    --navbar-height: 60px;
 }
 
 @keyframes spiral-in {
-    0% {
-        background-size: 200%;
-    }
-    100% {
-        background-size: 100%;
-    }
+    0% { background-size: 200%; }
+    100% { background-size: 100%; }
 }
 
 @keyframes infinite-scroll {
-    from { 
-        transform: translateX(0);
-    }
-    to { 
-        transform: translateX(-100%);
-    }
+    from { transform: translateX(0); }
+    to { transform: translateX(-100%); }
+}
+
+@keyframes spin-slow {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+}
+
+@keyframes float {
+    0%, 100% { transform: translateY(0px); }
+    50% { transform: translateY(-10px); }
+}
+
+@keyframes glow-pulse {
+    0%, 100% { opacity: 0.4; }
+    50% { opacity: 0.8; }
+}
+
+@keyframes wave {
+    0%, 100% { transform: scaleY(0.4); }
+    50% { transform: scaleY(1); }
 }
 
 @layer components {
@@ -49,71 +65,68 @@
 
     * {
         @apply font-primary;
-    
         scroll-margin-top: var(--navbar-height);
     }
-    
+
     p, label, input, textarea, li {
         @apply font-secondary;
     }
 
     span {
-        @apply text-gray-500 font-medium;
+        @apply text-white/50 font-medium;
     }
 
     h1, h2, h3, h4, h5, h6 {
-        @apply font-bold;
+        @apply font-bold text-white;
     }
 
-    h1 {
-        @apply text-2xl;
-    }
-
-    h2 {
-        @apply text-xl;
-    }
-
-    h3 {
-        @apply text-lg;
-    }
-
-    h4 {
-        @apply text-base;
-    }
-
-    h5 {
-        @apply text-sm;
-    }
-
-    h6 {
-        @apply text-xs;
-    }
+    h1 { @apply text-2xl; }
+    h2 { @apply text-xl; }
+    h3 { @apply text-lg; }
+    h4 { @apply text-base; }
+    h5 { @apply text-sm; }
+    h6 { @apply text-xs; }
 
     .tag {
-        @apply bg-primary;
+        @apply bg-white/10 text-white/70 border border-white/15;
 
         &[data-status="unige"] {
-            background-color: #D6005A;
+            background-color: rgba(214, 0, 90, 0.15);
+            border-color: rgba(214, 0, 90, 0.3);
+            color: #f472b6;
         }
 
         &[data-status="volunteering"] {
-            @apply bg-blue-500;
+            @apply bg-blue-500/15 border-blue-500/30 text-blue-400;
         }
 
         &[data-status="internship"] {
-            @apply bg-blue-500;
+            @apply bg-blue-500/15 border-blue-500/30 text-blue-400;
         }
     }
 
     .repo {
         .property {
             &[data-status="stars"] {
-                @apply text-yellow-500;
+                @apply text-yellow-400;
             }
 
             &[data-status="forks"] {
-                @apply text-gray-700;
+                @apply text-white/40;
             }
         }
+    }
+
+    .bento-card {
+        @apply relative rounded-3xl border border-white/[0.08] bg-neutral-900/60 backdrop-blur-xl overflow-hidden;
+    }
+
+    .scrollbar-hide {
+        -ms-overflow-style: none;
+        scrollbar-width: none;
+    }
+
+    .scrollbar-hide::-webkit-scrollbar {
+        display: none;
     }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata, Viewport } from "next";
-import { Montserrat, Poppins } from "next/font/google";
+import { Inter, Space_Grotesk } from "next/font/google";
 
 import "./globals.css";
 
@@ -11,69 +11,69 @@ import { NextIntlClientProvider } from "next-intl";
 import { getLocale, getMessages } from "next-intl/server";
 import { MetadataProps, getPageTranslations } from "./metadata";
 
-const montserrat = Montserrat({
-  subsets: ['latin'],
-  display: 'swap'
+const spaceGrotesk = Space_Grotesk({
+    subsets: ["latin"],
+    variable: "--font-space-grotesk",
+    display: "swap",
 });
 
-const poppins = Poppins({
-  subsets: ['latin'],
-  weight: ['100', '200', '300', '400', '500', '600', '700', '800', '900'],
-  display: 'swap'
+const inter = Inter({
+    subsets: ["latin"],
+    variable: "--font-inter",
+    weight: ["300", "400", "500", "600", "700"],
+    display: "swap",
 });
 
-export const isDev = process.env.NODE_ENV === 'development';
+export const isDev = process.env.NODE_ENV === "development";
 
 export const viewport: Viewport = {
-  themeColor: "#152238",
-}
+    themeColor: "#09090b",
+};
 
 export async function generateMetadata({ params }: MetadataProps): Promise<Metadata> {
-  const t = await getPageTranslations({ namespace: "global", params });
-  const devPrefix = isDev ? "[DEV]" : ""
+    const t = await getPageTranslations({ namespace: "global", params });
+    const devPrefix = isDev ? "[DEV]" : "";
 
-  return {
-    title: {
-      default: `${devPrefix} ${t("title")}`,
-      template: `${devPrefix} ${t("title")} — %s`
-    },
-    description: t("description"),
+    return {
+        title: {
+            default: `${devPrefix} ${t("title")}`,
+            template: `${devPrefix} ${t("title")} — %s`,
+        },
+        description: t("description"),
 
-    keywords: t("keywords"),
-    authors: { name: t("title"), url: "https://github.com/agonkolgeci/agonkolgeci.com-nextjs" },
-    
-    robots: { index: true, follow: true },
+        keywords: t("keywords"),
+        authors: { name: t("title"), url: "https://github.com/agonkolgeci/agonkolgeci.com-nextjs" },
 
-    openGraph: {
-      type: "website",
-      images: "https://agonkolgeci.com/banner_full.webp",
-      locale: params?.locale || await getDefaultLocale()
-    },
+        robots: { index: true, follow: true },
 
-    twitter: {
-      card: "summary",
-      images: "https://agonkolgeci.com/logo_full.webp"
-    }
-  }
+        openGraph: {
+            type: "website",
+            images: "https://agonkolgeci.com/banner_full.webp",
+            locale: params?.locale || (await getDefaultLocale()),
+        },
+
+        twitter: {
+            card: "summary",
+            images: "https://agonkolgeci.com/logo_full.webp",
+        },
+    };
 }
 
-export default async function RootLayout({ children }: { children: React.ReactNode; }) {
-  const locale = await getLocale();
-  const messages = await getMessages();
+export default async function RootLayout({ children }: { children: React.ReactNode }) {
+    const locale = await getLocale();
+    const messages = await getMessages();
 
-  return (
-    <html lang={locale}>
-      <body className="bg-primary text-white">
-        <NextIntlClientProvider messages={messages}>
-          <Header/>
+    return (
+        <html lang={locale}>
+            <body className={`${spaceGrotesk.variable} ${inter.variable} bg-primary text-white`}>
+                <NextIntlClientProvider messages={messages}>
+                    <Header />
 
-          <main className="w-full">
-            {children}
-          </main>
+                    <main className="w-full">{children}</main>
 
-          <Footer/>
-        </NextIntlClientProvider>
-      </body>
-    </html>
-  );
+                    <Footer />
+                </NextIntlClientProvider>
+            </body>
+        </html>
+    );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,102 +1,89 @@
-import { useTranslations } from "next-intl";
-import Image from "next/image";
-import Link from "next/link";
-import SocialsLinks from "./_components/navigation/socials/SocialsLinks";
-import Section from "./_components/pages/Section";
-import { ExternalURL } from "./_components/utils/ExternalLink";
-import { Button } from "./_components/utils/ui/Button";
-import { Card, CardContainer, CardImage } from "./_components/utils/ui/Card";
-import { Justify, Orientation } from "./_components/utils/ui/Render";
+import ClockWidget from "./_components/bento/ClockWidget";
+import ContactWidget from "./_components/bento/ContactWidget";
+import DiscoverWidget from "./_components/bento/DiscoverWidget";
+import GitHubWidget from "./_components/bento/GitHubWidget";
+import MusicWidget from "./_components/bento/MusicWidget";
+import ProfileCard from "./_components/bento/ProfileCard";
+import ProjectsWidget from "./_components/bento/ProjectsWidget";
+import StackWidget from "./_components/bento/StackWidget";
+import TimelineWidget from "./_components/bento/TimelineWidget";
 
 export default function Home() {
-    const t = useTranslations("home");
-
-    const Discover = ({ image, title, description, buttons, orientation } : { image: string, title: string, description: string, buttons?: ExternalURL[], orientation: Orientation }) => {
-        return (
-            <Card orientation={orientation}>
-                <CardImage src={image} alt={title} className="w-full h-[200px] lg:w-[500px] lg:h-[300px]" border="rounded-t-2xl lg:rounded-l-2xl lg:rounded-r-none" />
-
-                <CardContainer justify={Justify.BETWEEN}>
-                    <div className="flex flex-col gap-4">
-                        <h2>{title}</h2>
-                        <p>{description}</p>
-                    </div>
-
-                    <div className="flex flex-col md:flex-row gap-4 md:gap-8">
-                        {buttons?.map(button => {
-                            return (
-                                <Link key={button.name} href={button.href}>
-                                    <Button>{button.name}</Button>
-                                </Link>
-                            )
-                        })}
-                    </div>
-                </CardContainer>
-            </Card>
-        )
-    }
-
     return (
-        <div className="w-full bg-secondary">
-            <div className="bg-[url('/background.webp')] bg-cover bg-center">
-                <div className="flex flex-col items-center justify-center gap-2 max-w-5xl h-screen mx-auto px-10 text-center">
-                    <h1 className="bg-gradient-primary bg-clip-text text-transparent text-6xl leading-normal">{t("title")}</h1>
-                    <p className="text-4xl text-shadow">{t("description")}</p>
-                </div>
+        <div className="min-h-screen relative">
+            {/* Ambient background glows */}
+            <div className="fixed inset-0 pointer-events-none overflow-hidden z-0">
+                <div
+                    className="absolute top-1/4 left-[15%] w-[600px] h-[600px] rounded-full"
+                    style={{
+                        background: "radial-gradient(circle, rgba(99,102,241,0.06) 0%, transparent 70%)",
+                    }}
+                />
+                <div
+                    className="absolute bottom-1/3 right-[10%] w-[500px] h-[500px] rounded-full"
+                    style={{
+                        background: "radial-gradient(circle, rgba(139,92,246,0.06) 0%, transparent 70%)",
+                    }}
+                />
+                <div
+                    className="absolute top-[65%] left-[40%] w-[400px] h-[400px] rounded-full"
+                    style={{
+                        background: "radial-gradient(circle, rgba(34,197,94,0.04) 0%, transparent 70%)",
+                    }}
+                />
             </div>
 
-            <Section title={t("about.title")} description={t("about.description")} position={0}>
-                <div className="flex flex-col lg:flex-row items-center gap-16 max-w-7xl">
-                    <div className="flex">
-                        <figure className="block bg-gradient-primary w-[300px] h-[300px] relative rounded-2xl mt-4 ml-4">
-                            <Image className="object-cover object-center -translate-x-4 -translate-y-4 rounded-2xl" src="/home/portrait.webp" fill={true} alt="Portrait" />
-                        </figure>
+            {/* Bento Grid */}
+            <div className="relative z-10 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 lg:py-12">
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 lg:auto-rows-[195px] gap-4">
+
+                    {/* Profile — 2×2 */}
+                    <div className="col-span-1 md:col-span-2 lg:col-span-2 lg:row-span-2 min-h-[380px] lg:min-h-0">
+                        <ProfileCard />
                     </div>
 
-                    <div className="flex flex-col gap-8">
-                        <div className="flex flex-col gap-6 text-lg">
-                            {t("about.presentation").split(/(?<=\.|\?|\!)\s+/).map(text => <p key={text}>{text}</p>)}
-                        </div>
-
-                        <SocialsLinks className="flex flex-row gap-8 text-5xl text-primary" />
+                    {/* Clock — 1×1 */}
+                    <div className="col-span-1 min-h-[180px] lg:min-h-0">
+                        <ClockWidget />
                     </div>
+
+                    {/* Music — 1×1 */}
+                    <div className="col-span-1 min-h-[180px] lg:min-h-0">
+                        <MusicWidget />
+                    </div>
+
+                    {/* Stack Lab — 2×1 */}
+                    <div className="col-span-1 md:col-span-2 lg:col-span-2 min-h-[180px] lg:min-h-0">
+                        <StackWidget />
+                    </div>
+
+                    {/* GitHub — 2×1 */}
+                    <div className="col-span-1 md:col-span-2 lg:col-span-2 min-h-[190px] lg:min-h-0">
+                        <GitHubWidget />
+                    </div>
+
+                    {/* Projects — 2×1 */}
+                    <div className="col-span-1 md:col-span-2 lg:col-span-2 min-h-[220px] lg:min-h-0">
+                        <ProjectsWidget />
+                    </div>
+
+                    {/* Timeline — 4×1 */}
+                    <div className="col-span-1 md:col-span-2 lg:col-span-4 min-h-[200px] lg:min-h-0">
+                        <TimelineWidget />
+                    </div>
+
+                    {/* Contact — 2×1 */}
+                    <div className="col-span-1 md:col-span-1 lg:col-span-2 min-h-[220px] lg:min-h-0">
+                        <ContactWidget />
+                    </div>
+
+                    {/* Discover — 2×1 */}
+                    <div className="col-span-1 md:col-span-1 lg:col-span-2 min-h-[220px] lg:min-h-0">
+                        <DiscoverWidget />
+                    </div>
+
                 </div>
-            </Section>
-
-            <Section title={t("discover.title")} description={t("discover.description")} position={1}>
-                <div className="grid grid-cols-1 justify-center w-full gap-32 max-w-7xl">
-                    <Discover orientation={Orientation.HORIZONTAL} 
-                        image="/home/knowledge.webp"
-                        title={t("discover.knowledge.title")}
-                        description={t("discover.knowledge.description")}
-                        buttons={[
-                            { name: t("discover.knowledge.go_to_skills"), href: "/skills" },
-                            { name: t("discover.knowledge.go_to_education"), href: "/education" }
-                        ]}
-                    />
-
-                    <Discover orientation={Orientation.HORIZONTAL} 
-                        image="/home/career.webp"
-                        title={t("discover.career.title")}
-                        description={t("discover.career.description")}
-                        buttons={[
-                            { name: t("discover.career.go_to_experiences"), href: "/experiences" }
-                        ]}
-                    />
-
-                    <Discover orientation={Orientation.HORIZONTAL} 
-                        image="/home/creations.webp"
-                        title={t("discover.creations.title")}
-                        description={t("discover.creations.description")}
-                        buttons={[
-                            { name: t("discover.creations.go_to_gallery"), href: "/gallery" }
-                        ]}
-                    />
-                </div>
-            </Section>
-
-            {/* <Section title="Testimonials" description="" position={2}>
-            </Section> */}
+            </div>
         </div>
     );
 }


### PR DESCRIPTION
## Résumé

- Refonte complète du système de design : thème Obsidian Deep Black (`#09090b`), glassmorphism satiné (backdrop-blur, border-white/8), typographie Space Grotesk + Inter
- Nouvelle page d'accueil entièrement réécrite en grille Bento responsive (1→2→4 colonnes) avec 9 widgets interactifs
- Navbar glassmorphism sticky, Footer minimaliste redesigné
- Toutes les chaînes texte externalisées dans `messages/en.json` et `messages/fr.json`

## Widgets créés

| Widget | Description |
|--------|-------------|
| `ProfileCard` | Inclinaison 3D (Framer Motion), indicateur live animé, avatar, socials |
| `ClockWidget` | Horloge Genève en temps réel (Europe/Zurich), icône soleil/lune |
| `MusicWidget` | Lecteur simulé — vinyle rotatif + visualiseur d'ondes |
| `StackWidget` | Grille périodique des technologies avec animations décalées |
| `GitHubWidget` | Canvas de contributions stylisé, hover interactif |
| `ProjectsWidget` | 3 projets phares avec bandes accent et animations |
| `TimelineWidget` | Frise chronologique horizontale (6 jalons) |
| `ContactWidget` | Liens rapides email/LinkedIn/GitHub |
| `DiscoverWidget` | 4 tuiles de navigation vers les pages secondaires |

## Changements techniques

- `globals.css` : nouveau `@theme` obsidian, animations `spin-slow`, `float`, `wave`, `glow-pulse`, classe utilitaire `.scrollbar-hide`
- `layout.tsx` : fonts `Space_Grotesk` + `Inter` via `next/font/google` avec CSS variables
- `Header.tsx` : glassmorphism `backdrop-blur-xl` sticky
- `NavMenu.tsx` : style glassmorphism mobile + états actif/inactif redesignés
- Build `next build` : ✅ 0 erreur TypeScript, 10/10 pages compilées